### PR TITLE
Update build config file

### DIFF
--- a/HGOL.cabal
+++ b/HGOL.cabal
@@ -20,7 +20,7 @@ executable HGOL
   main-is:             Main.hs
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.7 && <4.9
                      , GLUT
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
The build config specifies at least a version of 4.8, which causes some problems on my Windows machine. After I lowered the minimum version to 4.7, it built just fine.
